### PR TITLE
fix : DDUK1-34 Address -> Building

### DIFF
--- a/src/main/java/com/JangKi/dducksang/Service/Building/BuildingService.java
+++ b/src/main/java/com/JangKi/dducksang/Service/Building/BuildingService.java
@@ -1,10 +1,20 @@
 package com.JangKi.dducksang.Service.Building;
 
+import com.JangKi.dducksang.APImodel.OpenAPI;
+import com.JangKi.dducksang.Service.Address.AddressService;
+import com.JangKi.dducksang.Web.Dto.BuildingDto.BuildingRequestDto;
+import com.JangKi.dducksang.Web.Dto.Map.MapListDto;
+import com.JangKi.dducksang.domain.Address.Repository.Address;
+import com.JangKi.dducksang.domain.Building.Repository.Building;
 import com.JangKi.dducksang.domain.Building.Repository.BuildingRepo;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Year;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -13,5 +23,67 @@ public class BuildingService {
 
     private final BuildingRepo buildingRepo;
 
+    private final AddressService addressService;
 
+    private final BuildingService buildingService;
+
+    private final OpenAPI openAPI;
+
+    @Transactional
+    public List<MapListDto> search(String code, String dealDay, String pageNo)
+    {
+        List<MapListDto> list = openAPI.getApi(code, dealDay, pageNo);
+
+        log.info("list sizeE : " + list.size());
+
+        return list;
+    }
+
+    @Transactional
+    public Long save(Building Entity)
+    {
+        Building saveBuilding = buildingRepo.save(Entity);
+
+        return saveBuilding.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Building searchBuildingID(int siCode, int epCode, String aptName)
+    {
+        return buildingRepo.searchBuilding(siCode, epCode, aptName);
+    }
+
+    @Transactional
+    public Long saveBuilding(MapListDto mapListDto)
+    {
+        Long BuildingID;
+        // 만약에 없으면
+        if(!buildingRepo.exist(mapListDto.getSigunguCode(), mapListDto.getEupmyundongCode(),mapListDto.getAptName()))
+        {
+            String codeStr = String.valueOf(mapListDto.getSigunguCode()) + String.valueOf(mapListDto.getEupmyundongCode());
+
+            Long code = Long.valueOf(codeStr);
+
+            Address address = addressService.searchSigunguCode(code);
+
+            Year year = Year.of(mapListDto.getBuildYear());
+
+            // Building을 저장해준다.
+            BuildingRequestDto.BuildingSaveDto buildingSaveDto = new BuildingRequestDto.BuildingSaveDto(year,
+                    mapListDto.getSigunguCode(), mapListDto.getEupmyundongCode(), mapListDto.getSigungu(), mapListDto.getDong(), mapListDto.getAptName());
+
+            buildingSaveDto.setAddressID(address);
+
+            Building saveBuilding = buildingSaveDto.toEntity();
+
+            BuildingID = buildingService.save(saveBuilding);
+        }
+
+        else{
+            Building building = buildingService.searchBuildingID(mapListDto.getSigunguCode(), mapListDto.getEupmyundongCode(),mapListDto.getAptName());
+            BuildingID = building.getId();
+        }
+
+        return BuildingID;
+    }
 }

--- a/src/main/java/com/JangKi/dducksang/domain/Building/Repository/BuildingRepo.java
+++ b/src/main/java/com/JangKi/dducksang/domain/Building/Repository/BuildingRepo.java
@@ -1,6 +1,18 @@
 package com.JangKi.dducksang.domain.Building.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface BuildingRepo extends JpaRepository<Building, Long> {
+@Repository
+public interface BuildingRepo extends JpaRepository<Building, Long>, BuildingRepoCustom{
+
+    @Query("SELECT b FROM Building b WHERE b.sigunguCode = :sigunguCode and b.eupmyundongCode = :eupmyundongCode and b.aptName = :aptName")
+    Building searchBuilding(@Param("sigunguCode") int sigunguCode, @Param("eupmyundongCode") int eupmyundongCode, @Param("aptName") String aptName);
+
+//    @Query("SELECT EXISTS (SELECT a.* FROM Address a WHERE a.)")
+
+    @Query("SELECT EXISTS (SELECT b FROM Building b where b.sigunguCode = :sigunguCode and b.eupmyundongCode = :eupmyundongCode and b.aptName = :aptName)")
+    Long ExistsBuilding(@Param("sigunguCode") int sigunguCode, @Param("eupmyundongCode") int eupmyundongCode, @Param("aptName") String aptName);
 }


### PR DESCRIPTION
1. Address -> Building 연결 코드 작성
- Address에 해당하는 Building이 이미 연결되어있을 때는 해당 column의 PK만 전달
- 저장이 안되어있을 경우, service의 save로직 수행 후 PK 전달

2. BuildingRepo에서 필요한 조회 쿼리 수정
- 해당 시군구, 읍면동, 아파트이름 조회시 해당 건물 반환 [ 아파트 이름 중복이 일어날 수 있어서 이렇게 지정 ]
- QueryDSL을 통해서 Exists로 해당 건물이 있는지 조회